### PR TITLE
fix: add ansible.compatibility_mode

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,5 +26,6 @@ Vagrant.configure("2") do |config|
 
     config.vm.provision "ansible" do |ansible|
         ansible.playbook = "ansible/vagrant-playbook.yml"
+        ansible.compatibility_mode = "2.0"
     end
 end


### PR DESCRIPTION
To remove the warning message about compatibility mode forcibly activated.
We are using Ansible 2+ (ansible [core 2.16.4])